### PR TITLE
Added LED-Glasses Examples

### DIFF
--- a/LED-Countdown/LED-Countdown.ino
+++ b/LED-Countdown/LED-Countdown.ino
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Deepak Khatri - deepak@upsidedownlabs.tech
+// Copyright (c) 2025 Krishnanshu Mittal - krishnanshu@upsidedownlabs.tech
+
+#define BOOT_PIN 9
+
+// Pin Assignments
+const uint8_t DATA_COL = 9;   // Columns → 74HC595 DS
+const uint8_t CLK_COL  = 15;  // Columns → 74HC595 SH_CP
+const uint8_t DATA_ROW = 18;  // Rows    → 74HC595 DS
+const uint8_t CLK_ROW  = 20;  // Rows    → 74HC595 SH_CP
+const uint8_t LATCH    = 14;  // Shared  → 74HC595 ST_CP
+
+// Matrix Dimensions
+const uint8_t NUM_COLS = 24;
+const uint8_t NUM_ROWS = 8;
+
+// Each digit is defined as a 4x5 pattern (columns 4-7, rows 1-5)
+const bool digitPatterns[10][7][5] = {
+  // 0
+  {
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 1, 1},
+    {1, 0, 1, 0, 1},
+    {1, 1, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0}
+  },
+  // 1
+  {
+    {0, 0, 1, 0, 0},
+    {0, 1, 1, 0, 0},
+    {1, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0},
+    {1, 1, 1, 1, 1}
+  },
+  // 2
+  {
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {0, 0, 0, 0, 1},
+    {0, 0, 1, 1, 0},
+    {0, 1, 0, 0, 0},
+    {1, 0, 0, 0, 0},
+    {1, 1, 1, 1, 1}
+  },
+  // 3
+  {
+    {1, 1, 1, 1, 0},
+    {0, 0, 0, 0, 1},
+    {0, 0, 0, 0, 1},
+    {0, 0, 1, 1, 0},
+    {0, 0, 0, 0, 1},
+    {0, 0, 0, 0, 1},
+    {1, 1, 1, 1, 0}
+  },
+  // 4
+  {
+    {0, 0, 0, 1, 0},
+    {0, 0, 1, 1, 0},
+    {0, 1, 0, 1, 0},
+    {1, 0, 0, 1, 0},
+    {1, 1, 1, 1, 1},
+    {0, 0, 0, 1, 0},
+    {0, 0, 0, 1, 0}
+  },
+  // 5
+  {
+    {1, 1, 1, 1, 1},
+    {1, 0, 0, 0, 0},
+    {1, 1, 1, 1, 0},
+    {0, 0, 0, 0, 1},
+    {0, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0}
+  },
+  // 6
+  {
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 0, 0},
+    {1, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0}
+  },
+  // 7
+  {
+    {1, 1, 1, 1, 1},
+    {0, 0, 0, 0, 1},
+    {0, 0, 0, 1, 0},
+    {0, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0},
+    {0, 0, 1, 0, 0}
+  },
+  // 8
+  {
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0}
+  },
+  // 9
+  {
+    {0, 1, 1, 1, 0},
+    {1, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 1},
+    {0, 0, 0, 0, 1},
+    {1, 0, 0, 0, 1},
+    {0, 1, 1, 1, 0}
+  }
+};
+
+
+// LED State Tracking
+bool ledStates[NUM_COLS][NUM_ROWS] = {false};
+
+// Initialize all hardware pins
+void initPins() {
+  pinMode(DATA_COL, OUTPUT);
+  pinMode(CLK_COL, OUTPUT);
+  pinMode(DATA_ROW, OUTPUT);
+  pinMode(CLK_ROW, OUTPUT);
+  pinMode(LATCH, OUTPUT);
+  digitalWrite(LATCH, LOW);
+}
+
+// Clear all LED states
+void clearAllLEDs() {
+  for (uint8_t col = 0; col < NUM_COLS; col++) {
+    for (uint8_t row = 0; row < NUM_ROWS; row++) {
+      ledStates[col][row] = false;
+    }
+  }
+}
+
+// Set an individual LED state (in memory)
+void setLED(uint8_t col, uint8_t row, bool state) {
+  if (col < NUM_COLS && row < NUM_ROWS) {
+    ledStates[col][row] = state;
+  }
+}
+
+// Refresh the entire display (one row at a time)
+void refreshDisplay() {
+  for (uint8_t row = 0; row < NUM_ROWS; row++) {
+    uint8_t colData[3] = {0, 0, 0};
+    
+    // Build column data for this row
+    for (uint8_t col = 0; col < NUM_COLS; col++) {
+      if (ledStates[col][row]) {
+        colData[col / 8] |= (1 << (col % 8));
+      }
+    }
+    
+    // Activate only this row (active low)
+    uint8_t rowData = ~(1 << row);
+    
+    // Update shift registers
+    digitalWrite(LATCH, LOW);
+    for (int8_t i = 2; i >= 0; i--) {
+      shiftOut(DATA_COL, CLK_COL, MSBFIRST, colData[i]);
+    }
+    shiftOut(DATA_ROW, CLK_ROW, MSBFIRST, rowData);
+    digitalWrite(LATCH, HIGH);
+    
+    // Brief delay for LED persistence
+    delayMicroseconds(300);
+  }
+}
+
+// ─── DISPLAY DIGIT FUNCTION ────────────────────────────────────────────────
+void displayDigit(uint8_t digit, uint8_t startCol, uint8_t startRow) {
+  if (digit > 9) return; // Only 0-9 supported
+  
+  for (uint8_t row = 0; row < 7; row++) {
+    for (uint8_t col = 0; col < 5; col++) {
+      setLED(startCol + col, startRow + row, digitPatterns[digit][row][col]);
+    }
+  }
+}
+
+void setup() {
+  initPins();
+  clearAllLEDs();
+}
+
+void loop() {
+  for(int i = 99; i >= 0; i--) {
+    clearAllLEDs();            // Clear before displaying new digit
+    displayDigit(int(i/10), 3, 0);     // Display the digit
+    displayDigit(int(i%10), 16, 0);
+    
+    // Display for 500ms with continuous refresh
+    unsigned long startTime = millis();
+    while(millis() - startTime < 500) {
+      refreshDisplay();        // Keep refreshing while displaying
+    }
+  }
+}

--- a/LED-Matrix/LED-Matrix.ino
+++ b/LED-Matrix/LED-Matrix.ino
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Deepak Khatri - deepak@upsidedownlabs.tech
+// Copyright (c) 2025 Krishnanshu Mittal - krishnanshu@upsidedownlabs.tech
+
+/*
+  To display a custom text or pattern on the LED Matrix:
+  1. Go to https://dotmatrixtool.com
+  2. Select the dimensions of the LED Matrix(Width:24 x Height:8)
+  3. Draw the pattern or text you want to display by clicking and dragging on the Matrix. You can clear any selected box by CTRL + LEFT Click
+  4. Click on Generate button to generate the data in hex format.
+  5. Copy the data (Only the hex values) and paste it in our data[] array in code below.
+*/
+
+// Pin Definitions
+const uint8_t DATA_COL = 9;
+const uint8_t CLK_COL  = 15;
+const uint8_t DATA_ROW = 18;
+const uint8_t CLK_ROW  = 20;
+const uint8_t LATCH    = 14;
+
+// Matrix Dimensions
+const uint8_t NUM_COLS = 24;
+const uint8_t NUM_ROWS = 8;
+
+// Generated Data from DotMatrixTool
+
+const uint8_t data[] =
+{
+// Paste below your custom data generated from https://dotmatrixtool.com
+0x00, 0x1e, 0x21, 0x21, 0x21, 0x00, 0x00, 0x0e, 0x11, 0x09, 0x05, 0x03, 0x03, 0x05, 0x09, 0x11, 0x0e, 0x00, 0x00, 0x1f, 0x20, 0x20, 0x20, 0x00
+};
+
+
+void setup() {
+  pinMode(DATA_COL, OUTPUT);
+  pinMode(CLK_COL, OUTPUT);
+  pinMode(DATA_ROW, OUTPUT);
+  pinMode(CLK_ROW, OUTPUT);
+  pinMode(LATCH, OUTPUT);
+}
+
+void loop() {
+  for (uint8_t row = 0; row < NUM_ROWS; row++) {
+    uint8_t rowData = ~(1 << row); // Active low for current row
+    uint8_t colData[3] = {0, 0, 0}; // For 24 columns
+
+    for (uint8_t col = 0; col < NUM_COLS; col++) {
+      if (data[col] & (1 << row)) {
+        colData[col / 8] |= (1 << (col % 8));
+      }
+    }
+
+    digitalWrite(LATCH, LOW);
+    // Shift out column data (MSB first)
+    for (int8_t i = 2; i >= 0; i--) {
+      shiftOut(DATA_COL, CLK_COL, MSBFIRST, colData[i]);
+    }
+    // Shift out row data
+    shiftOut(DATA_ROW, CLK_ROW, MSBFIRST, rowData);
+    digitalWrite(LATCH, HIGH);
+
+    delayMicroseconds(100); // Adjust for brightness and flicker
+  }
+}

--- a/LED-Scan/LED-Scan.ino
+++ b/LED-Scan/LED-Scan.ino
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Deepak Khatri - deepak@upsidedownlabs.tech
+
+// ─── PIN ASSIGNMENTS ───────────────────────────────────────────────────────────
+const uint8_t DATA_COL = 9;   // Columns → 74HC595 DS
+const uint8_t CLK_COL  = 15;  // Columns → 74HC595 SH_CP
+const uint8_t DATA_ROW = 18;  // Rows    → 74HC595 DS
+const uint8_t CLK_ROW  = 20;  // Rows    → 74HC595 SH_CP
+const uint8_t LATCH    = 14;  // Shared  → 74HC595 ST_CP
+
+// ─── MATRIX DIMENSIONS ─────────────────────────────────────────────────────────
+const uint8_t NUM_COLS = 24;
+const uint8_t NUM_ROWS = 8;
+
+// ─── FUNCTION TO SET A SINGLE LED ──────────────────────────────────────────────
+void setLED(uint8_t col, uint8_t row) {
+  uint8_t colData[3] = {0, 0, 0}; // 3 bytes for 24 columns
+  uint8_t rowData = 0xFF;         // All rows HIGH (inactive)
+
+  // Set the specific column bit
+  if (col < NUM_COLS) {
+    colData[col / 8] = 1 << (col % 8);
+  }
+
+  // Set the specific row bit to LOW (active)
+  if (row < NUM_ROWS) {
+    rowData = ~(1 << row);
+  }
+
+  // Shift out the data
+  digitalWrite(LATCH, LOW);
+    // Shift out column data (MSB first)
+    for (int8_t i = 2; i >= 0; i--) {
+      shiftOut(DATA_COL, CLK_COL, MSBFIRST, colData[i]);
+    }
+    // Shift out row data
+    shiftOut(DATA_ROW, CLK_ROW, MSBFIRST, rowData);
+  digitalWrite(LATCH, HIGH);
+}
+
+void setup() {
+  pinMode(DATA_COL, OUTPUT);
+  pinMode(CLK_COL, OUTPUT);
+  pinMode(DATA_ROW, OUTPUT);
+  pinMode(CLK_ROW, OUTPUT);
+  pinMode(LATCH, OUTPUT);
+}
+
+void loop() {
+  // Iterate through each LED in the matrix
+  for (uint8_t row = 0; row < NUM_ROWS; row++) {
+    for (uint8_t col = 0; col < NUM_COLS; col++) {
+      setLED(col, row);
+      delay(100); // Delay to observe the LED
+    }
+  }
+}


### PR DESCRIPTION
Added three new LED‑Glasses examples
Thanks to @lorforlinux for the original hardware and base codes!
1. LED‑Scan – steps through each LED for easy testing
2. LED‑Matrix – displays arbitrary patterns or text
3. LED‑Countdown – counts down from 99 to 00